### PR TITLE
feat(default): add immich-drop for collecting photos/videos

### DIFF
--- a/kubernetes/apps/prod/default/immich/drop/README.md
+++ b/kubernetes/apps/prod/default/immich/drop/README.md
@@ -1,0 +1,56 @@
+# immich-drop
+
+A tiny, zero-login web app for collecting photos/videos from anyone into your Immich server.
+
+## Description
+
+immich-drop allows admin users to create public invite links for uploading photos/videos directly to your Immich server. Invite links are public-by-URL and can be configured with passwords, album assignment, and expiry dates.
+
+## Dependencies
+
+- [immich](../immich/) - Required: Immich server must be running
+
+## Configuration
+
+### Required Secrets
+
+| Key              | Description                                                                                                                |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `IMMICH_API_KEY` | Immich API key with asset.upload permissions (and album.create, album.read, albumAsset.create if album support is enabled) |
+
+Note: `SESSION_SECRET` is auto-generated if not provided.
+
+### Environment Variables
+
+| Variable                     | Default                               | Description                                     |
+| ---------------------------- | ------------------------------------- | ----------------------------------------------- |
+| `IMMICH_BASE_URL`            | `https://immich.${SECRET_DOMAIN}/api` | Immich API base URL                             |
+| `IMMICH_API_KEY`             | (secret)                              | API key for Immich                              |
+| `PUBLIC_UPLOAD_PAGE_ENABLED` | `false`                               | Enable public upload page (disabled by default) |
+| `IMMICH_ALBUM_NAME`          | (not set)                             | Album name to auto-assign uploads to            |
+| `SESSION_SECRET`             | (secret)                              | Session encryption secret                       |
+| `CHUNKED_UPLOADS_ENABLED`    | `false`                               | Enable chunked uploads for large files          |
+| `CHUNK_SIZE_MB`              | `95`                                  | Chunk size in MB                                |
+
+## Usage
+
+**When needed:**
+
+1. Temporarily enable password login on Immich server (Server Settings → Password Authentication)
+2. Scale up the app:
+   ```bash
+   kubectl scale hr immich-drop -n default --replicas=1
+   ```
+
+**After use:**
+
+1. Scale down the app:
+   ```bash
+   kubectl scale hr immich-drop -n default --replicas=0
+   ```
+2. Disable password login on Immich server
+
+## Upstream Documentation
+
+- GitHub: https://github.com/Nasogaa/immich-drop
+- Docker Image: `ghcr.io/nasogaa/immich-drop`

--- a/kubernetes/apps/prod/default/immich/drop/kustomization.yaml
+++ b/kubernetes/apps/prod/default/immich/drop/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - "./secret.sops.yaml"
+  - "./pvc.yaml"
+  - "./release.yaml"

--- a/kubernetes/apps/prod/default/immich/drop/pvc.yaml
+++ b/kubernetes/apps/prod/default/immich/drop/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-drop
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100M
+  storageClassName: rook-ceph-block

--- a/kubernetes/apps/prod/default/immich/drop/release.yaml
+++ b/kubernetes/apps/prod/default/immich/drop/release.yaml
@@ -1,0 +1,77 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app immich-drop
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  values:
+    controllers:
+      immich-drop:
+        replicas: 0
+        pod:
+          nodeSelector:
+            kubernetes.io/arch: amd64
+        containers:
+          main:
+            image:
+              repository: ghcr.io/nasogaa/immich-drop
+              tag: v0.5.0
+            env:
+              CHUNKED_UPLOADS_ENABLED: "true"
+              IMMICH_BASE_URL: http://immich-server:2283/api
+              IMMICH_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-drop-secret
+                    key: IMMICH_API_KEY
+              PUBLIC_UPLOAD_PAGE_ENABLED: "false"
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
+    service:
+      main:
+        controller: immich-drop
+        ports:
+          http:
+            port: 8080
+
+    ingress:
+      main:
+        enabled: true
+        className: external
+        annotations:
+          external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
+          nginx.ingress.kubernetes.io/proxy-body-size: 10m
+        hosts:
+          - host: "drop.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+        tls:
+          - hosts:
+              - "drop.${SECRET_DOMAIN}"
+
+    persistence:
+      data:
+        enabled: true
+        type: persistentVolumeClaim
+        existingClaim: immich-drop
+        globalMounts:
+          - path: /data
+
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/prod/default/immich/drop/secret.sops.yaml
+++ b/kubernetes/apps/prod/default/immich/drop/secret.sops.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: immich-drop-secret
+stringData:
+  IMMICH_API_KEY: ENC[AES256_GCM,data:guwZ67LvtaoLBkWdjqbQ8t6aCcVP+Mat3SkkR5h/ezXrogx3Zu+HMVuE,iv:aAzuL810st2Zeu50KGVMVyo8+GMlNOpZ+yA2h6FqMHI=,tag:tT67KC4IdB6yxuyZcKPDJQ==,type:str]
+sops:
+  lastmodified: "2026-04-14T10:20:49Z"
+  mac: ENC[AES256_GCM,data:MZ9XNbHrZdNJXNkQD/vlJj7f55UZXrah4j/QnPn9itJy2TdLhGLFbRgOgZ+Zp18BL5jHQa3DmRVxSx1pYQLSYVJcbs91XgBMesqbD8Aw38ZaUMNsYfgoB3hPcozCUJwDxquRhpb8SO3jcezaRUJ65oL33HILVzJXTIwAKeOjzl4=,iv:i9YjSS6bke40M+OKh0gYCwZTygMzpdi4qc1oiq1R37o=,tag:L6FBF6ljU7tnmCOHvNiS6w==,type:str]
+  pgp:
+    - created_at: "2026-04-14T10:20:49Z"
+      enc: |-
+        -----BEGIN PGP MESSAGE-----
+
+        hQIMA06fffInlMOLAQ//QJKSn7sME+TbevEPLM0ZjJk9xhxOiePpWHsbPbwKOYXN
+        MhPs53TKsxAU6CsER5PL7h4ZbeisyCz6H/1UJkZRVdoklemc/fjbMA3v3Y4AqRqB
+        WfL7M0jCC225DzAWsTvFb6dzzWjGYK8bI+83OeQ9HnBfyTfGKPjRPH5pNi8I1EIp
+        2Q6/eSG1SIa0HGhyKRMOdR4F46FdSzevTTnL09UzPamBBJtxrjPCXy1DDMmqTfqI
+        iFnwXSL/hMhOGJINnBC4DRNrDzY3gfOCVfsmF9N6MwsKTfcBMmCYt5gy33+vCwKP
+        TVGOx36azilmBBtglGzQAgxE5620GL4YlbpRbXXPPCvI5KlQgNb1FlSZd5XJ5VF7
+        YM9e5Fvv6Iv4CHrMYssHV0IPDE/CX5ENJ5cDCBU0V02L+WeeWTa2o4fqOgsxAn7v
+        8fxhdGWb/v0RfT65XeH0hHA4NTAHiLRBPRv1teZk4TNLYTDZgCONq5coJ/3J9UPu
+        WqEtAu+s1UZEtP+ewYTA+f+SxADqnrCTjrIEw+VpheJKuMXUwJbfbJJGmt3m9EQU
+        /f/jayRR8+UTrRHKv0z27dzLWxIureQnY4dcVBI4rDuHidqJ+QIdObUrTKwsoOQ7
+        7LtyqbbqDP9AgHnGL9LFXmcKXV0qzT5frSzuYll5ZQd8cryalg6YL2vmSPfs/pLS
+        XAGqpSfM0in6M4geyZi5gPtxR9Ho0nd4mXtASrclvwd4lRfhVH2TM2BPqgvlwdDx
+        1EVvdyaXde/xZ9euNi8rriVBJCLUVo0RILIGTbKeQrGtMvL8r2jCeKNWcIrU
+        =zzxz
+        -----END PGP MESSAGE-----
+      fp: E9F6BEBC269B2E8B8AE07E3784A740B5B323BDD3
+  encrypted_regex: ^(data|stringData)$
+  version: 3.12.2

--- a/kubernetes/apps/prod/default/immich/ks.yaml
+++ b/kubernetes/apps/prod/default/immich/ks.yaml
@@ -47,3 +47,24 @@ spec:
   postBuild:
     substitute:
       APP: *appname
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: immich-drop
+  namespace: flux-system
+spec:
+  targetNamespace: default
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/apps/prod/default/immich/drop
+  prune: true
+  wait: true
+  dependsOn:
+    - name: immich
+      namespace: flux-system


### PR DESCRIPTION
Adds immich-drop as a sub-app to the immich deployment. immich-drop provides public invite links for uploading photos/videos directly to the Immich server. Default replicas set to 0 - scale up when needed.

Closes #749