### PR TITLE
feat(coffee-diary): add boilerplate for coffee diary app

### DIFF
--- a/kubernetes/apps/prod/default/coffee-diary/api/kustomization.yaml
+++ b/kubernetes/apps/prod/default/coffee-diary/api/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - "./release.yaml"

--- a/kubernetes/apps/prod/default/coffee-diary/api/release.yaml
+++ b/kubernetes/apps/prod/default/coffee-diary/api/release.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app coffee-diary-api
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  interval: 15m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 185
+        runAsGroup: 185
+        fsGroup: 185
+        fsGroupChangePolicy: OnRootMismatch
+
+    controllers:
+      coffee-diary-api:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/frederiks/coffee-diary-api
+              tag: 0.0.1
+            env:
+              TZ: ${TIMEZONE}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+
+    service:
+      app:
+        ports:
+          http:
+            port: 8080
+
+    persistence:
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/prod/default/coffee-diary/ks.yaml
+++ b/kubernetes/apps/prod/default/coffee-diary/ks.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname coffee-diary-api
+  namespace: flux-system
+spec:
+  targetNamespace: default
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/apps/prod/default/coffee-diary/api
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      APP: *appname
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname coffee-diary-ui
+  namespace: flux-system
+spec:
+  targetNamespace: default
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/apps/prod/default/coffee-diary/ui
+  prune: true
+  wait: true
+  dependsOn:
+    - name: coffee-diary-api
+  postBuild:
+    substitute:
+      APP: *appname

--- a/kubernetes/apps/prod/default/coffee-diary/ui/kustomization.yaml
+++ b/kubernetes/apps/prod/default/coffee-diary/ui/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - "./release.yaml"

--- a/kubernetes/apps/prod/default/coffee-diary/ui/release.yaml
+++ b/kubernetes/apps/prod/default/coffee-diary/ui/release.yaml
@@ -1,0 +1,89 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app coffee-diary-ui
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  interval: 15m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+
+    controllers:
+      coffee-diary-ui:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/frederiks/coffee-diary-ui
+              tag: 0.0.1
+            env:
+              TZ: ${TIMEZONE}
+              API_URL: http://coffee-diary-api:8080
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 30
+                  failureThreshold: 3
+              readiness: *probe
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 32Mi
+
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+
+    ingress:
+      app:
+        className: internal
+        hosts:
+          - host: &host "coffee.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - *host
+
+    persistence:
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /var/cache/nginx
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/prod/default/kustomization.yaml
+++ b/kubernetes/apps/prod/default/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - "./typst/ks.yaml"
   - "./bentopdf/ks.yaml"
   - "./linkding/ks.yaml"
+  - "./coffee-diary/ks.yaml"


### PR DESCRIPTION
Add coffee-diary app with api and ui components. UI depends on API and exposes internal ingress at coffee.${SECRET_DOMAIN}.