### PR TITLE
feat(media): add profilarr to media namespace

### DIFF
--- a/kubernetes/apps/prod/media/kustomization.yaml
+++ b/kubernetes/apps/prod/media/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - "./navidrome/ks.yaml"
   - "./metube/ks.yaml"
   - "./stash/ks.yaml"
+  - "./profilarr/ks.yaml"

--- a/kubernetes/apps/prod/media/profilarr/README.md
+++ b/kubernetes/apps/prod/media/profilarr/README.md
@@ -1,0 +1,24 @@
+# Profilarr
+
+Profile validator for Radarr/Sonarr.
+
+## Dependencies
+
+- Rook Ceph cluster (for PVC)
+- `${SECRET_DOMAIN}` variable defined
+
+## Configuration
+
+- Internal ingress only (accessible within the home network)
+- Uses existing PVC for config storage
+- Authentication disabled for local use
+
+## Notes
+
+- Image: `ghcr.io/dictionarry-hub/profilarr`
+- Port: 6868
+- Health endpoint: `/api/v1/health`
+
+## Links
+
+- [GitHub](https://github.com/dictionarry-hub/profilarr)

--- a/kubernetes/apps/prod/media/profilarr/app/kustomization.yaml
+++ b/kubernetes/apps/prod/media/profilarr/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - "./repository.yaml"
+  - "./pvc.yaml"
+  - "./release.yaml"

--- a/kubernetes/apps/prod/media/profilarr/app/pvc.yaml
+++ b/kubernetes/apps/prod/media/profilarr/app/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: profilarr
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: rook-ceph-block

--- a/kubernetes/apps/prod/media/profilarr/app/release.yaml
+++ b/kubernetes/apps/prod/media/profilarr/app/release.yaml
@@ -1,0 +1,117 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: profilarr
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: profilarr
+  maxHistory: 2
+  install:
+    timeout: 10m
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    timeout: 10m
+    remediation:
+      retries: 3
+      strategy: rollback
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    controllers:
+      profilarr:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/dictionarry-hub/profilarr
+              tag: 2.0.3
+            env:
+              TZ: ${TIMEZONE}
+              PORT: &port 6868
+              PUID: 1000
+              PGID: 1000
+              ORIGIN: https://profilarr.${SECRET_DOMAIN}
+              AUTH: "off"
+              UMASK: "022"
+            probes:
+              liveness: &probes
+                enabled: false
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/health
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 2
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: false
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/health
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 2
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 700Mi
+
+    service:
+      app:
+        controller: profilarr
+        ports:
+          http:
+            port: *port
+
+    ingress:
+      app:
+        className: internal
+        hosts:
+          - host: &host "profilarr.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - *host
+
+    persistence:
+      config:
+        enabled: true
+        existingClaim: profilarr
+        advancedMounts:
+          profilarr:
+            app:
+              - path: /config
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/prod/media/profilarr/app/repository.yaml
+++ b/kubernetes/apps/prod/media/profilarr/app/repository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: =https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: profilarr
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/prod/media/profilarr/ks.yaml
+++ b/kubernetes/apps/prod/media/profilarr/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname profilarr
+  namespace: flux-system
+spec:
+  targetNamespace: media
+  interval: 1h
+  retryInterval: 1m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/apps/prod/media/profilarr/app
+  prune: true
+  wait: true
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *appname


### PR DESCRIPTION
Adds profilarr profile validator for Radarr/Sonarr to the media namespace. Uses app-template with internal ingress and Rook Ceph storage.

Closes #800